### PR TITLE
Fixes and improvements for port forwarding tests

### DIFF
--- a/docker/DockerFile
+++ b/docker/DockerFile
@@ -33,7 +33,11 @@ RUN apk add --no-cache syslog-ng && \
     addgroup sshnetadm sudo && \
     dos2unix /opt/sshnet/* && \
     # install shadow package; we use chage command in this package to expire/unexpire password of the sshnet user
-    apk add --no-cache shadow
+    apk add --no-cache shadow && \
+    # allow us to use telnet command; we use this in the remote port forwarding tests
+    apk --no-cache add busybox-extras && \
+    # install full-fledged ps command
+    apk add --no-cache procps
 
 EXPOSE 22 22
 

--- a/src/SshNetTests/Common/RemoteSshdConfigExtensions.cs
+++ b/src/SshNetTests/Common/RemoteSshdConfigExtensions.cs
@@ -11,6 +11,7 @@ namespace SshNetTests.Common
             remoteSshdConfig.WithAuthenticationMethods(Users.Regular.UserName, DefaultAuthenticationMethods)
                             .WithChallengeResponseAuthentication(false)
                             .WithKeyboardInteractiveAuthentication(false)
+                            .PrintMotd()
                             .WithLogLevel(LogLevel.Debug3)
                             .ClearHostKeyFiles()
                             .AddHostKeyFile(HostKeyFile.Rsa.FilePath)

--- a/src/SshNetTests/PrivateKeyAuthenticationTests.cs
+++ b/src/SshNetTests/PrivateKeyAuthenticationTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Renci.SshNet;
+using SshNet.TestTools.OpenSSH;
 using SshNetTests.Common;
 
 namespace SshNetTests
@@ -29,22 +30,46 @@ namespace SshNetTests
         [TestMethod]
         public void Ecdsa256()
         {
+            _remoteSshdConfig.AddPublicKeyAcceptedAlgorithms(PublicKeyAlgorithm.EcdsaSha2Nistp256)
+                             .Update()
+                             .Restart();
+
             var connectionInfo = _connectionInfoFactory.Create(CreatePrivateKeyAuthenticationMethod("key_ecdsa_256_openssh"));
 
             using (var client = new SshClient(connectionInfo))
             {
                 client.Connect();
-                client.Disconnect();
             }
         }
 
+        [TestMethod]
         public void Ecdsa384()
         {
+            _remoteSshdConfig.AddPublicKeyAcceptedAlgorithms(PublicKeyAlgorithm.EcdsaSha2Nistp384)
+                             .Update()
+                             .Restart();
 
+            var connectionInfo = _connectionInfoFactory.Create(CreatePrivateKeyAuthenticationMethod("key_ecdsa_384_openssh"));
+
+            using (var client = new SshClient(connectionInfo))
+            {
+                client.Connect();
+            }
         }
 
+        [TestMethod]
         public void EcdsaA521()
         {
+            _remoteSshdConfig.AddPublicKeyAcceptedAlgorithms(PublicKeyAlgorithm.EcdsaSha2Nistp521)
+                             .Update()
+                             .Restart();
+
+            var connectionInfo = _connectionInfoFactory.Create(CreatePrivateKeyAuthenticationMethod("key_ecdsa_521_openssh"));
+
+            using (var client = new SshClient(connectionInfo))
+            {
+                client.Connect();
+            }
         }
 
         private PrivateKeyAuthenticationMethod CreatePrivateKeyAuthenticationMethod(string keyResource)

--- a/src/SshNetTests/RemoteSshd.cs
+++ b/src/SshNetTests/RemoteSshd.cs
@@ -102,6 +102,32 @@ namespace SshNetTests
             return this;
         }
 
+        /// <summary>
+        /// Specifies whether <c>sshd</c> should print /etc/motd when a user logs in interactively.
+        /// </summary>
+        /// <param name="value"><see langword="true"/> if <c>sshd</c> should print /etc/motd when a user logs in interactively.</param>
+        /// <returns>
+        /// The current <see cref="RemoteSshdConfig"/> instance.
+        /// </returns>
+        public RemoteSshdConfig PrintMotd(bool? value = true)
+        {
+            _config.PrintMotd = value;
+            return this;
+        }
+
+        /// <summary>
+        /// Specifies whether TCP forwarding is permitted.
+        /// </summary>
+        /// <param name="value"><see langword="true"/> to allow TCP forwarding.</param>
+        /// <returns>
+        /// The current <see cref="RemoteSshdConfig"/> instance.
+        /// </returns>
+        public RemoteSshdConfig AllowTcpForwarding(bool? value = true)
+        {
+            _config.AllowTcpForwarding = value;
+            return this;
+        }
+
         public RemoteSshdConfig WithAuthenticationMethods(string user, string authenticationMethods)
         {
             var sshNetMatch = _config.Matches.FirstOrDefault(m => m.Users.Contains(user));


### PR DESCRIPTION
* Support configuration of **PrintMotd** and **AllowTcpForwarding** options.
* Fix and extend public key authentication tests.
* Fix port forwarding tests.
* Add intermittend output test for **ShellStream**.
* Add few tests for `SftpClient.Open(...)`.