### PR TITLE
Refactor network disruption code

### DIFF
--- a/src/SshNetTests/ConnectivityTests.cs
+++ b/src/SshNetTests/ConnectivityTests.cs
@@ -2,13 +2,9 @@
 using Renci.SshNet;
 using Renci.SshNet.Common;
 using Renci.SshNet.Messages.Transport;
+using SshNet.TestTools.OpenSSH;
 using SshNetTests.Common;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Management;
-using System.Text.RegularExpressions;
 using System.Threading;
 
 namespace SshNetTests
@@ -16,8 +12,7 @@ namespace SshNetTests
     [TestClass]
     public class ConnectivityTests : TestBase
     {
-        private const string NetworkConnectionId = "Ethernet 2";
-
+        private readonly NetworkConnectivityDisruptor _networkConnectivityDisruptor = NetworkConnectivityDisruptor.Create();
         private AuthenticationMethodFactory _authenticationMethodFactory;
         private IConnectionInfoFactory _connectionInfoFactory;
         private IConnectionInfoFactory _adminConnectionInfoFactory;
@@ -68,61 +63,22 @@ namespace SshNetTests
         [TestMethod]
         public void Common_DisposeAfterLossOfNetworkConnectivity()
         {
-            var hostNetworkConnectionDisabled = false;
-
             try
             {
-                Exception errorOccurred = null;
-
-                using (var client = new SftpClient(_connectionInfoFactory.Create()))
-                {
-                    client.ErrorOccurred += (sender, args) => errorOccurred = args.Exception;
-                    client.Connect();
-
-                    DisableHostNetworkConnection(NetworkConnectionId);
-                    hostNetworkConnectionDisabled = true;
-                }
-
-                Assert.IsNotNull(errorOccurred);
-                Assert.AreEqual(typeof(SshConnectionException), errorOccurred.GetType());
-
-                var connectionException = (SshConnectionException) errorOccurred;
-                Assert.AreEqual(DisconnectReason.ConnectionLost, connectionException.DisconnectReason);
-                Assert.IsNull(connectionException.InnerException);
-                Assert.AreEqual("An established connection was aborted by the server.", connectionException.Message);
-            }
-            finally
-            {
-                if (hostNetworkConnectionDisabled)
-                {
-                    EnableHostNetworkConnection(NetworkConnectionId);
-                    ResetVirtualMachineNetworkConnection();
-                }
-            }
-        }
-
-        [TestMethod]
-        public void Common_DetectLossOfNetworkConnectivityThroughKeepAlive()
-        {
-            using (var client = new SftpClient(_connectionInfoFactory.Create()))
-            {
-                Exception errorOccurred = null;
-                client.ErrorOccurred += (sender, args) => errorOccurred = args.Exception;
-                client.KeepAliveInterval = new TimeSpan(0, 0, 0, 0, 50);
-                client.Connect();
-
-                DisableHostNetworkConnection(NetworkConnectionId);
+                var hostNetworkConnectionDisabled = false;
 
                 try
                 {
-                    for (var i = 0; i < 500; i++)
-                    {
-                        if (!client.IsConnected)
-                            break;
-                        Thread.Sleep(100);
-                    }
+                    Exception errorOccurred = null;
 
-                    Assert.IsFalse(client.IsConnected);
+                    using (var client = new SftpClient(_connectionInfoFactory.Create()))
+                    {
+                        client.ErrorOccurred += (sender, args) => errorOccurred = args.Exception;
+                        client.Connect();
+
+                        _networkConnectivityDisruptor.Start();
+                        hostNetworkConnectionDisabled = true;
+                    }
 
                     Assert.IsNotNull(errorOccurred);
                     Assert.AreEqual(typeof(SshConnectionException), errorOccurred.GetType());
@@ -134,137 +90,206 @@ namespace SshNetTests
                 }
                 finally
                 {
-                    EnableHostNetworkConnection(NetworkConnectionId);
-                    ResetVirtualMachineNetworkConnection();
-                }
-            }
-        }
-
-        [TestMethod]
-        public void Common_DetectConnectionResetThroughSftpInvocation()
-        {
-            using (var client = new SftpClient(_connectionInfoFactory.Create()))
-            {
-                ManualResetEvent errorOccurredSignaled = new ManualResetEvent(false);
-                Exception errorOccurred = null;
-                client.ErrorOccurred += (sender, args) =>
+                    if (hostNetworkConnectionDisabled)
                     {
-                        errorOccurred = args.Exception;
-                        errorOccurredSignaled.Set();
-                    };
-                client.Connect();
-
-                DisableHostNetworkConnection(NetworkConnectionId);
-
-                try
-                {
-                    client.ListDirectory("/");
-                    Assert.Fail();
+                        _networkConnectivityDisruptor.End();
+                    }
                 }
-                catch (SshConnectionException ex)
-                {
-                    Assert.IsNull(ex.InnerException);
-                    Assert.AreEqual("Client not connected.", ex.Message);
-
-                    Assert.IsNotNull(errorOccurred);
-                    Assert.AreEqual(typeof(SshConnectionException), errorOccurred.GetType());
-
-                    var connectionException = (SshConnectionException) errorOccurred;
-                    Assert.AreEqual(DisconnectReason.ConnectionLost, connectionException.DisconnectReason);
-                    Assert.IsNull(connectionException.InnerException);
-                    Assert.AreEqual("An established connection was aborted by the server.", connectionException.Message);
-                }
-                finally
-                {
-                    EnableHostNetworkConnection(NetworkConnectionId);
-                    ResetVirtualMachineNetworkConnection();
-                }
+            }
+            catch (NetworkConnectivityDisruptorException ex)
+            {
+                Assert.Inconclusive(ex.Message);
             }
         }
 
         [TestMethod]
-        public void Common_LossOfNetworkConnectivityDisconnectAndConnect()
+        public void Common_DetectLossOfNetworkConnectivityThroughKeepAlive()
         {
-            bool vmNetworkConnectionDisabled = false;
-
             try
             {
                 using (var client = new SftpClient(_connectionInfoFactory.Create()))
                 {
                     Exception errorOccurred = null;
                     client.ErrorOccurred += (sender, args) => errorOccurred = args.Exception;
-
+                    client.KeepAliveInterval = new TimeSpan(0, 0, 0, 0, 50);
                     client.Connect();
 
-                    DisableVirtualMachineNetworkConnection();
-                    vmNetworkConnectionDisabled = true;
-                    ResetVirtualMachineNetworkConnection();
+                    _networkConnectivityDisruptor.Start();
 
-                    // disconnect while network connectivity is lost
-                    client.Disconnect();
+                    try
+                    {
 
-                    Assert.IsFalse(client.IsConnected);
+                        for (var i = 0; i < 500; i++)
+                        {
+                            if (!client.IsConnected)
+                                break;
+                            Thread.Sleep(100);
+                        }
 
-                    EnableVirtualMachineNetworkConnection();
-                    vmNetworkConnectionDisabled = false;
-                    ResetVirtualMachineNetworkConnection();
+                        Assert.IsFalse(client.IsConnected);
 
-                    // connect when network connectivity is restored
-                    client.Connect();
-                    client.ChangeDirectory(client.WorkingDirectory);
-                    client.Dispose();
+                        Assert.IsNotNull(errorOccurred);
+                        Assert.AreEqual(typeof(SshConnectionException), errorOccurred.GetType());
 
-                    Assert.IsNull(errorOccurred);
+                        var connectionException = (SshConnectionException)errorOccurred;
+                        Assert.AreEqual(DisconnectReason.ConnectionLost, connectionException.DisconnectReason);
+                        Assert.IsNull(connectionException.InnerException);
+                        Assert.AreEqual("An established connection was aborted by the server.", connectionException.Message);
+                    }
+                    finally
+                    {
+                        _networkConnectivityDisruptor.End();
+                    }
                 }
             }
-            finally
+            catch (NetworkConnectivityDisruptorException ex)
             {
-                if (vmNetworkConnectionDisabled)
+                Assert.Inconclusive(ex.Message);
+            }
+        }
+
+        [TestMethod]
+        public void Common_DetectConnectionResetThroughSftpInvocation()
+        {
+            try
+            {
+                using (var client = new SftpClient(_connectionInfoFactory.Create()))
                 {
-                    EnableVirtualMachineNetworkConnection();
-                    ResetVirtualMachineNetworkConnection();
+                    client.KeepAliveInterval = TimeSpan.FromSeconds(1);
+                    client.OperationTimeout = TimeSpan.FromSeconds(60);
+                    ManualResetEvent errorOccurredSignaled = new ManualResetEvent(false);
+                    Exception errorOccurred = null;
+                    client.ErrorOccurred += (sender, args) =>
+                        {
+                            errorOccurred = args.Exception;
+                            errorOccurredSignaled.Set();
+                        };
+                    client.Connect();
+
+                    _networkConnectivityDisruptor.Start();
+
+                    try
+                    {
+                        client.ListDirectory("/");
+                        Assert.Fail();
+                    }
+                    catch (SshConnectionException ex)
+                    {
+                        Assert.IsNull(ex.InnerException);
+                        Assert.AreEqual("Client not connected.", ex.Message);
+
+                        Assert.IsNotNull(errorOccurred);
+                        Assert.AreEqual(typeof(SshConnectionException), errorOccurred.GetType());
+
+                        var connectionException = (SshConnectionException)errorOccurred;
+                        Assert.AreEqual(DisconnectReason.ConnectionLost, connectionException.DisconnectReason);
+                        Assert.IsNull(connectionException.InnerException);
+                        Assert.AreEqual("An established connection was aborted by the server.", connectionException.Message);
+                    }
+                    finally
+                    {
+                        _networkConnectivityDisruptor.End();
+                    }
                 }
+            }
+            catch (NetworkConnectivityDisruptorException ex)
+            {
+                Assert.Inconclusive(ex.Message);
+            }
+        }
+
+        [TestMethod]
+        public void Common_LossOfNetworkConnectivityDisconnectAndConnect()
+        {
+            try
+            {
+                bool vmNetworkConnectionDisabled = false;
+
+                try
+                {
+                    using (var client = new SftpClient(_connectionInfoFactory.Create()))
+                    {
+                        Exception errorOccurred = null;
+                        client.ErrorOccurred += (sender, args) => errorOccurred = args.Exception;
+
+                        client.Connect();
+
+                        _networkConnectivityDisruptor.Start();
+                        vmNetworkConnectionDisabled = true;
+
+                        // disconnect while network connectivity is lost
+                        client.Disconnect();
+
+                        Assert.IsFalse(client.IsConnected);
+
+                        _networkConnectivityDisruptor.End();
+                        vmNetworkConnectionDisabled = false;
+
+                        // connect when network connectivity is restored
+                        client.Connect();
+                        client.ChangeDirectory(client.WorkingDirectory);
+                        client.Dispose();
+
+                        Assert.IsNull(errorOccurred);
+                    }
+                }
+                finally
+                {
+                    if (vmNetworkConnectionDisabled)
+                    {
+                        _networkConnectivityDisruptor.End();
+                    }
+                }
+            }
+            catch (NetworkConnectivityDisruptorException ex)
+            {
+                Assert.Inconclusive(ex.Message);
             }
         }
 
         [TestMethod]
         public void Common_DetectLossOfNetworkConnectivityThroughSftpInvocation()
         {
-            using (var client = new SftpClient(_connectionInfoFactory.Create()))
+            try
             {
-                ManualResetEvent errorOccurredSignaled = new ManualResetEvent(false);
-                Exception errorOccurred = null;
-                client.ErrorOccurred += (sender, args) =>
+                using (var client = new SftpClient(_connectionInfoFactory.Create()))
+                {
+                    ManualResetEvent errorOccurredSignaled = new ManualResetEvent(false);
+                    Exception errorOccurred = null;
+                    client.ErrorOccurred += (sender, args) =>
+                        {
+                            errorOccurred = args.Exception;
+                            errorOccurredSignaled.Set();
+                        };
+                    client.Connect();
+
+                    _networkConnectivityDisruptor.Start();
+
+                    try
                     {
-                        errorOccurred = args.Exception;
-                        errorOccurredSignaled.Set();
-                    };
-                client.Connect();
-
-                DisableVirtualMachineNetworkConnection();
-                ResetVirtualMachineNetworkConnection();
-
-                try
-                {
-                    client.ListDirectory("/");
-                    Assert.Fail();
+                        client.ListDirectory("/");
+                        Assert.Fail();
+                    }
+                    catch (SshConnectionException ex)
+                    {
+                        Assert.AreEqual(DisconnectReason.ConnectionLost, ex.DisconnectReason);
+                        Assert.IsNull(ex.InnerException);
+                        Assert.AreEqual("An established connection was aborted by the server.", ex.Message);
+                    }
+                    finally
+                    {
+                        _networkConnectivityDisruptor.End();
+                    }
                 }
-                catch (SshConnectionException ex)
-                {
-                    Assert.AreEqual(DisconnectReason.ConnectionLost, ex.DisconnectReason);
-                    Assert.IsNull(ex.InnerException);
-                    Assert.AreEqual("An established connection was aborted by the server.", ex.Message);
-                }
-                finally
-                {
-                    EnableVirtualMachineNetworkConnection();
-                    ResetVirtualMachineNetworkConnection();
-                }
+            }
+            catch (NetworkConnectivityDisruptorException ex)
+            {
+                Assert.Inconclusive(ex.Message);
             }
         }
 
         [TestMethod]
-        public void  Common_DetectSessionKilledOnServer()
+        public void Common_DetectSessionKilledOnServer()
         {
             using (var client = new SftpClient(_connectionInfoFactory.Create()))
             {
@@ -387,205 +412,7 @@ namespace SshNetTests
             }
         }
 
-        private static void DisableHostNetworkConnection(string networkConnection)
-        {
-            SelectQuery wmiQuery = new SelectQuery("SELECT * FROM Win32_NetworkAdapter WHERE NetConnectionId != NULL");
-            ManagementObjectSearcher searchProcedure = new ManagementObjectSearcher(wmiQuery);
-            foreach (ManagementObject item in searchProcedure.Get())
-            {
-                var netConnectionId = (string)item["NetConnectionId"];
 
-                if (netConnectionId == networkConnection)
-                {
-                    var returnValue = item.InvokeMethod("Disable", null);
-                    if (returnValue is uint retValue)
-                    {
-                        if (retValue == 0)
-                        {
-                            return;
-                        }
 
-                        throw new ApplicationException($"Failed to disable '{networkConnection}' network connection. Return value is {retValue}.{Environment.NewLine}Make sure you're running the tests with elevated priviliges.");
-                    }
-                    else if (returnValue == null)
-                    {
-                        throw new ApplicationException($"Failed to disable '{networkConnection}' network connection. Return value is null.");
-                    }
-                    else
-                    {
-                        throw new ApplicationException($"Failed to disable '{networkConnection}' network connection. Unexpected return value {returnValue} ({returnValue.GetType()}).");
-                    }
-                }
-            }
-
-            throw new ApplicationException($"Failed to disable '{networkConnection}' network connection. Network connection not found.");
-        }
-
-        private static void EnableHostNetworkConnection(string networkConnection)
-        {
-            SelectQuery wmiQuery = new SelectQuery("SELECT * FROM Win32_NetworkAdapter WHERE NetConnectionId != NULL");
-            ManagementObjectSearcher searchProcedure = new ManagementObjectSearcher(wmiQuery);
-            foreach (ManagementObject item in searchProcedure.Get())
-            {
-                var netConnectionId = (string)item["NetConnectionId"];
-
-                if (netConnectionId == networkConnection)
-                {
-                    var returnValue = item.InvokeMethod("Enable", null);
-                    if (returnValue is uint retValue)
-                    {
-                        if (retValue == 0u)
-                        {
-                            Console.WriteLine($"Enable host network connection for '{networkConnection}'.");
-                            Thread.Sleep(5000);
-                            return;
-                        }
-
-                        throw new ApplicationException($"Failed to enable '{networkConnection}' network connection. Return value is {retValue}..{Environment.NewLine}Make sure you're running the tests with elevated priviliges.");
-                    }
-                    else if (returnValue == null)
-                    {
-                        throw new ApplicationException($"Failed to enable '{networkConnection}' network connection. Return value is null.");
-                    }
-                    else
-                    {
-                        throw new ApplicationException($"Failed to enable '{networkConnection}' network connection. Unexpected return value {returnValue} ({returnValue.GetType()}).");
-                    }
-                }
-            }
-
-            throw new ApplicationException($"Failed to enable '{networkConnection}' network connection. Network connection not found.");
-        }
-
-        private static string VirtualBoxFolder
-        {
-            get
-            {
-                if (Environment.Is64BitOperatingSystem)
-                {
-                    if (!Environment.Is64BitProcess)
-                    {
-                        // dotnet test runs tests in a 32-bit process (no watter what I f***in' try), so let's hard-code the
-                        // path to VirtualBox
-                        return Path.Combine("c:\\Program Files", "Oracle", "VirtualBox");
-                    }
-                }
-
-                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Oracle", "VirtualBox");
-            }
-        }
-
-        private static List<string> GetRunningVMs()
-        {
-            var runningVmRegex = new Regex("\"(?<name>.+?)\"\\s?(?<uuid>{.+?})");
-
-            var startInfo = new ProcessStartInfo
-                {
-                    FileName = Path.Combine(VirtualBoxFolder, "VBoxManage.exe"),
-                    Arguments = "list runningvms",
-                    RedirectStandardOutput = true,
-                    UseShellExecute = false
-                };
-
-            var process = Process.Start(startInfo);
-            process.WaitForExit();
-
-            if (process.ExitCode != 0)
-            {
-                throw new ApplicationException($"Failed to get list of running VMs. Exit code is {process.ExitCode}.");
-            }
-
-            var runningVms = new List<string>();
-
-            string line;
-
-            while ((line = process.StandardOutput.ReadLine()) != null)
-            {
-                var match = runningVmRegex.Match(line);
-                if (match != null)
-                {
-                    runningVms.Add(match.Groups["name"].Value);
-                }
-            }
-
-            return runningVms;
-        }
-
-        private static void SetLinkState(string vmName, bool on)
-        {
-            var linkStateValue = (on ? "on" : "off");
-
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = Path.Combine(VirtualBoxFolder, "VBoxManage.exe"),
-                Arguments = $"controlvm \"{vmName}\" setlinkstate1 {linkStateValue}",
-                RedirectStandardOutput = true,
-                UseShellExecute = false
-            };
-
-            var process = Process.Start(startInfo);
-            process.WaitForExit();
-
-            if (process.ExitCode != 0)
-            {
-                throw new ApplicationException($"Failed to set linkstate for VM '{vmName}' to '{linkStateValue}'. Exit code is {process.ExitCode}.");
-            }
-            else
-            {
-                Console.WriteLine($"Changed linkstate for VM '{vmName}' to '{linkStateValue}.");
-            }
-        }
-
-        private static void SetPromiscuousMode(string vmName, string value)
-        {
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = Path.Combine(VirtualBoxFolder, "VBoxManage.exe"),
-                Arguments = $"controlvm \"{vmName}\" nicpromisc1 {value}",
-                RedirectStandardOutput = true,
-                UseShellExecute = false
-            };
-
-            var process = Process.Start(startInfo);
-            process.WaitForExit();
-
-            if (process.ExitCode != 0)
-            {
-                throw new ApplicationException($"Failed to set promiscuous for VM '{vmName}' to '{value}'. Exit code is {process.ExitCode}.");
-            }
-            else
-            {
-                Console.WriteLine($"Changed promiscuous for VM '{vmName}' to '{value}'.");
-            }
-        }
-
-        private static void DisableVirtualMachineNetworkConnection()
-        {
-            var runningVMs = GetRunningVMs();
-            Assert.AreEqual(1, runningVMs.Count);
-
-            SetLinkState(runningVMs[0], false);
-            Thread.Sleep(1000);
-        }
-
-        private static void EnableVirtualMachineNetworkConnection()
-        {
-            var runningVMs = GetRunningVMs();
-            Assert.AreEqual(1, runningVMs.Count);
-
-            SetLinkState(runningVMs[0], true);
-            Thread.Sleep(1000);
-        }
-
-        private static void ResetVirtualMachineNetworkConnection()
-        {
-            var runningVMs = GetRunningVMs();
-            Assert.AreEqual(1, runningVMs.Count);
-
-            SetPromiscuousMode(runningVMs[0], "allow-all");
-            Thread.Sleep(1000);
-            SetPromiscuousMode(runningVMs[0], "deny");
-            Thread.Sleep(1000);
-        }
     }
 }

--- a/src/SshNetTests/Temp4Tools/DockerNetworkConnectivityDisruptor.cs
+++ b/src/SshNetTests/Temp4Tools/DockerNetworkConnectivityDisruptor.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace SshNet.TestTools.OpenSSH
+{
+    public sealed class DockerNetworkConnectivityDisruptor : NetworkConnectivityDisruptor
+    {
+        public DockerNetworkConnectivityDisruptor(string containerName)
+        {
+            ContainerName = containerName;
+        }
+
+        private string ContainerName { get; }
+
+        public override void Start()
+        {
+            var process = DockerCommand($"pause {ContainerName}");
+            if (!process.WaitForExit(30000))
+            {
+                process.Kill();
+                throw new ApplicationException("Failed to pause the 'sshnet' container: timed out.");
+            }
+            if (process.ExitCode != 0)
+            {
+                throw new ApplicationException($"Failed to pause the 'sshnet' container: status {process.ExitCode}.");
+            }
+        }
+
+        public override void End()
+        {
+            var process = DockerCommand($"unpause {ContainerName}");
+            if (!process.WaitForExit(30000))
+            {
+                process.Kill();
+                throw new ApplicationException("Failed to resume the 'sshnet' container: timed out.");
+            }
+            if (process.ExitCode != 0)
+            {
+                throw new ApplicationException($"Failed to resume the 'sshnet' container: status {process.ExitCode}.");
+            }
+        }
+
+        private static Process DockerCommand(string command)
+        {
+            return Process.Start(
+                new ProcessStartInfo
+                {
+                    FileName = "docker",
+                    Arguments = command,
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false
+                });
+        }
+    }
+}

--- a/src/SshNetTests/Temp4Tools/NetworkConnectivityDisruptor.cs
+++ b/src/SshNetTests/Temp4Tools/NetworkConnectivityDisruptor.cs
@@ -1,0 +1,17 @@
+﻿namespace SshNet.TestTools.OpenSSH
+{
+    public abstract class NetworkConnectivityDisruptor
+    {
+        public abstract void Start();
+
+        public abstract void End();
+
+        public static NetworkConnectivityDisruptor Create()
+        {
+            // ToDo: Here we decide which environment we are running in... somehow :)
+            // Maybe environment variables: easy to setup and persist independently of the code?
+//            return new DockerNetworkConnectivityDisruptor(containerName: "sshnet");
+            return new PhysicalNetworkConnectivityDisruptor(connectionName: "Management");
+        }
+    }
+}

--- a/src/SshNetTests/Temp4Tools/NetworkConnectivityDisruptorException.cs
+++ b/src/SshNetTests/Temp4Tools/NetworkConnectivityDisruptorException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace SshNet.TestTools.OpenSSH
+{
+    public sealed class NetworkConnectivityDisruptorException : Exception
+    {
+        public NetworkConnectivityDisruptorException(string message, Exception innerException) :
+            base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/SshNetTests/Temp4Tools/PhysicalNetworkConnectivityDisruptor.cs
+++ b/src/SshNetTests/Temp4Tools/PhysicalNetworkConnectivityDisruptor.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.ComponentModel;
+using System.Management;
+
+namespace SshNet.TestTools.OpenSSH
+{
+    public sealed class PhysicalNetworkConnectivityDisruptor : NetworkConnectivityDisruptor
+    {
+        public PhysicalNetworkConnectivityDisruptor(string connectionName)
+        {
+            ConnectionName = connectionName ?? throw new ArgumentNullException(nameof(connectionName));
+        }
+
+        private string ConnectionName { get; }
+
+
+        public override void Start()
+        {
+            try
+            {
+                InvokeMethod(GetNetConnection(ConnectionName), "Disable");
+            }
+            catch (Exception ex)
+            {
+                throw new NetworkConnectivityDisruptorException($"Failed to disable network connection '{ConnectionName}': {ex.Message}", ex);
+            }
+        }
+
+        public override void End()
+        {
+            try
+            {
+                InvokeMethod(GetNetConnection(ConnectionName), "Enable");
+            }
+            catch (Exception ex)
+            {
+                throw new NetworkConnectivityDisruptorException($"Failed to enable network connection '{ConnectionName}': {ex.Message}", ex);
+            }
+        }
+
+        private ManagementObject GetNetConnection(string connectionName)
+        {
+            // ToDo: We could probably cache the ManagementObject
+            SelectQuery wmiQuery = new SelectQuery($"SELECT * FROM Win32_NetworkAdapter WHERE NetConnectionId = '{connectionName}'");
+            ManagementObjectSearcher searchProcedure = new ManagementObjectSearcher(wmiQuery);
+            foreach (ManagementObject item in searchProcedure.Get())
+            {
+                return item;
+            }
+
+            throw new Exception("The connection does not exist.");
+        }
+
+        private void InvokeMethod(ManagementObject networkConnection, string methodName)
+        {
+            var returnValue = (uint)networkConnection.InvokeMethod(methodName, null);
+            if (returnValue != 0)
+            {
+                throw new Win32Exception(unchecked((int)returnValue));
+            }
+        }
+    }
+}

--- a/src/SshNetTests/Temp4Tools/VirtualBoxNetworkConnectivityDisruptor.cs
+++ b/src/SshNetTests/Temp4Tools/VirtualBoxNetworkConnectivityDisruptor.cs
@@ -9,16 +9,36 @@ namespace SshNet.TestTools.OpenSSH
 {
     public sealed class VirtualBoxNetworkConnectivityDisruptor : NetworkConnectivityDisruptor
     {
-        private const string vmName = "sshnet";
+        public VirtualBoxNetworkConnectivityDisruptor(string machineName)
+        {
+            MachineName = machineName;
+        }
+
+        private string MachineName { get; }
+
 
         public override void Start()
         {
-            SetLinkState(vmName, on: false);
+            try
+            {
+                SetLinkState(MachineName, on: false);
+            }
+            catch (Exception ex)
+            {
+                throw new NetworkConnectivityDisruptorException($"Failed to disable link for VM '{MachineName}': {ex.Message}", ex);
+            }
         }
 
         public override void End()
         {
-            SetLinkState(vmName, on: true);
+            try
+            {
+                SetLinkState(MachineName, on: true);
+            }
+            catch (Exception ex)
+            {
+                throw new NetworkConnectivityDisruptorException($"Failed to enable link for VM '{MachineName}': {ex.Message}", ex);
+            }
         }
 
         private static string VirtualBoxFolder
@@ -126,7 +146,7 @@ namespace SshNet.TestTools.OpenSSH
         private static void DisableVirtualMachineNetworkConnection()
         {
             var runningVMs = GetRunningVMs();
-//            Assert.AreEqual(1, runningVMs.Count);
+            //            Assert.AreEqual(1, runningVMs.Count);
 
             SetLinkState(runningVMs[0], false);
             Thread.Sleep(1000);
@@ -135,7 +155,7 @@ namespace SshNet.TestTools.OpenSSH
         private static void EnableVirtualMachineNetworkConnection()
         {
             var runningVMs = GetRunningVMs();
-//            Assert.AreEqual(1, runningVMs.Count);
+            //            Assert.AreEqual(1, runningVMs.Count);
 
             SetLinkState(runningVMs[0], true);
             Thread.Sleep(1000);
@@ -144,7 +164,7 @@ namespace SshNet.TestTools.OpenSSH
         private static void ResetVirtualMachineNetworkConnection()
         {
             var runningVMs = GetRunningVMs();
-//            Assert.AreEqual(1, runningVMs.Count);
+            //            Assert.AreEqual(1, runningVMs.Count);
 
             SetPromiscuousMode(runningVMs[0], "allow-all");
             Thread.Sleep(1000);

--- a/src/SshNetTests/Temp4Tools/VirtualBoxNetworkConnectivityDisruptor.cs
+++ b/src/SshNetTests/Temp4Tools/VirtualBoxNetworkConnectivityDisruptor.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading;
+
+namespace SshNet.TestTools.OpenSSH
+{
+    public sealed class VirtualBoxNetworkConnectivityDisruptor : NetworkConnectivityDisruptor
+    {
+        private const string vmName = "sshnet";
+
+        public override void Start()
+        {
+            SetLinkState(vmName, on: false);
+        }
+
+        public override void End()
+        {
+            SetLinkState(vmName, on: true);
+        }
+
+        private static string VirtualBoxFolder
+        {
+            get
+            {
+                if (Environment.Is64BitOperatingSystem)
+                {
+                    if (!Environment.Is64BitProcess)
+                    {
+                        // dotnet test runs tests in a 32-bit process (no watter what I f***in' try), so let's hard-code the
+                        // path to VirtualBox
+                        return Path.Combine("c:\\Program Files", "Oracle", "VirtualBox");
+                    }
+                }
+
+                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Oracle", "VirtualBox");
+            }
+        }
+
+        private static List<string> GetRunningVMs()
+        {
+            var runningVmRegex = new Regex("\"(?<name>.+?)\"\\s?(?<uuid>{.+?})");
+
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = Path.Combine(VirtualBoxFolder, "VBoxManage.exe"),
+                Arguments = "list runningvms",
+                RedirectStandardOutput = true,
+                UseShellExecute = false
+            };
+
+            var process = Process.Start(startInfo);
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+            {
+                throw new ApplicationException($"Failed to get list of running VMs. Exit code is {process.ExitCode}.");
+            }
+
+            var runningVms = new List<string>();
+
+            string line;
+
+            while ((line = process.StandardOutput.ReadLine()) != null)
+            {
+                var match = runningVmRegex.Match(line);
+                if (match != null)
+                {
+                    runningVms.Add(match.Groups["name"].Value);
+                }
+            }
+
+            return runningVms;
+        }
+
+        private static void SetLinkState(string vmName, bool on)
+        {
+            var linkStateValue = (on ? "on" : "off");
+
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = Path.Combine(VirtualBoxFolder, "VBoxManage.exe"),
+                Arguments = $"controlvm \"{vmName}\" setlinkstate1 {linkStateValue}",
+                RedirectStandardOutput = true,
+                UseShellExecute = false
+            };
+
+            var process = Process.Start(startInfo);
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+            {
+                throw new ApplicationException($"Failed to set linkstate for VM '{vmName}' to '{linkStateValue}'. Exit code is {process.ExitCode}.");
+            }
+            else
+            {
+                Console.WriteLine($"Changed linkstate for VM '{vmName}' to '{linkStateValue}.");
+            }
+        }
+
+        private static void SetPromiscuousMode(string vmName, string value)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = Path.Combine(VirtualBoxFolder, "VBoxManage.exe"),
+                Arguments = $"controlvm \"{vmName}\" nicpromisc1 {value}",
+                RedirectStandardOutput = true,
+                UseShellExecute = false
+            };
+
+            var process = Process.Start(startInfo);
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+            {
+                throw new ApplicationException($"Failed to set promiscuous for VM '{vmName}' to '{value}'. Exit code is {process.ExitCode}.");
+            }
+            else
+            {
+                Console.WriteLine($"Changed promiscuous for VM '{vmName}' to '{value}'.");
+            }
+        }
+
+        private static void DisableVirtualMachineNetworkConnection()
+        {
+            var runningVMs = GetRunningVMs();
+//            Assert.AreEqual(1, runningVMs.Count);
+
+            SetLinkState(runningVMs[0], false);
+            Thread.Sleep(1000);
+        }
+
+        private static void EnableVirtualMachineNetworkConnection()
+        {
+            var runningVMs = GetRunningVMs();
+//            Assert.AreEqual(1, runningVMs.Count);
+
+            SetLinkState(runningVMs[0], true);
+            Thread.Sleep(1000);
+        }
+
+        private static void ResetVirtualMachineNetworkConnection()
+        {
+            var runningVMs = GetRunningVMs();
+//            Assert.AreEqual(1, runningVMs.Count);
+
+            SetPromiscuousMode(runningVMs[0], "allow-all");
+            Thread.Sleep(1000);
+            SetPromiscuousMode(runningVMs[0], "deny");
+            Thread.Sleep(1000);
+        }
+
+    }
+}


### PR DESCRIPTION
@drieseng here is my take on the subject. Trying to abort network connections using docker seemed trivial at first, but failed miserably in the end. I tried pausing the container, but Docker's network stack seems to function as a reverse proxy: even when the container is paused, it would still accept network connections and autonomously respond to TCP keepalives.
Stopping the container of course nicely closes network connections, which is not what we want in this case.

In the process I have refactored the code to have a clean separation of different methods we could use to disrupt network connectivity. I have also made tests inconclusive in case network disruption fails. I think this is worth including in the codebase. Please have a look and let me know.

Apart from moving VirtualBox support into separate class I have not touched it as I don't have any VirtualBox experience. I presume this is something you can have a look at later?

I merged, this will fix #4.